### PR TITLE
Add cumsum pscan

### DIFF
--- a/src/pscan_cumsum.py
+++ b/src/pscan_cumsum.py
@@ -1,0 +1,33 @@
+import torch
+
+"""
+CumSum-based implementation of PSCAN by Maxim Zubkov
+https://github.com/maximzubkov/fft-scan/src/cumsum.py
+"""
+
+def pscan_cumsum(A, X):
+    N, T, D = X.shape
+    device = X.device
+
+    # A_log \in [N x T]
+    A_log = torch.log(A.to(dtype=torch.cfloat))
+
+    CS = A_log.cumsum(dim=-1)
+    # A_log.sum(dim=-1) + A_log - A_log.cumsum(dim=-1) = A_log[:, ::-1].cumsum(dim=-1)[:, ::-1]
+    UA = CS[:, -1].unsqueeze(-1) + A_log - CS
+
+    W = UA
+    W_max = W.real.max()
+    e_W = torch.exp(W - W_max).real
+    e_W = e_W.unsqueeze(-1)
+
+    V = -UA + A_log
+    V_max = V.real.max()
+    e_V = torch.exp(V - V_max).real
+    e_V = e_V.unsqueeze(-1)
+    Y_ = e_V * torch.cumsum(e_W * X, dim=1) * (torch.exp(V_max + W_max))
+
+    # After exp we no longer have complex components
+    Y_ = torch.cat([torch.zeros(N, 1, D, device=device), Y_[:, :-1, :]], dim=1)
+    Y = Y_ + X
+    return Y

--- a/src/pscan_fft.py
+++ b/src/pscan_fft.py
@@ -2,7 +2,7 @@ import torch
 
 """
 FFT-based implementation of PSCAN by Maxim Zubkov
-https://github.com/maximzubkov/fft-scan/blob/main/fft-scan.ipynb
+https://github.com/maximzubkov/fft-scan/src/fft_efficient.py
 """
 
 def L_at_X(X):


### PR DESCRIPTION
Hello, @dvruette, and Happy New Year!

As we discussed in the [issue](https://github.com/dvruette/barrel-rec-pytorch/issues/1), there might be alternative variants of PScan. Initially, I proposed an [FFT-based implementation](https://github.com/maximzubkov/fft-scan/blob/main/src/fft_efficeint.py), but its efficiency fell short of expectations. I tried to optimize it even more and subsequently managed to come up with a simpler yet more efficient approach. The key was to replace all FFT operations with simple `cumsum`, check [this](https://github.com/maximzubkov/fft-scan/blob/main/src/cumsum.py) for more details as well as the [README](https://github.com/maximzubkov/fft-scan/blob/main/README.md) for the underlying theory.

In terms of complexity, I benchmarked the performance against PScan in your repository [by François Fleuret](https://fleuret.org/cgi-bin/gitweb/gitweb.cgi) (referred to as FF in my experiments). While both exhibit the same asymptotic complexity, FF outperforms in actual execution time. However, I observed FF's occasional instability in specific cases of matrix $A$  (this might be caused by multiple `mul_` operations resulting in float overflow). Have you encountered similar issues in your experiments? In contrast, my `cusum` implementation leverages a [trick](https://github.com/maximzubkov/fft-scan/blob/5f0828a68a4036090e8578fbedc54be8d197aace/src/cumsum.py#L17) commonly used in `softmax` computations, avoiding observed instabilities, but this needs to be checked in the real-world training setting, ofc

Benchmarking conducted with NVIDIA V100, see [Dockerfile](https://github.com/maximzubkov/fft-scan/blob/main/Dockerfile) for the environment details, and [benchmark.py](https://github.com/maximzubkov/fft-scan/blob/main/benchmark.py). I didn't include `pscan_fft.py` in the benchmarking since the results are much worse than `ff` and `cumsum`, in line with what you observed running the training.

![f](https://github.com/dvruette/barrel-rec-pytorch/assets/47659865/f62e0096-1005-4ead-b132-3f536907561b)
![fb](https://github.com/dvruette/barrel-rec-pytorch/assets/47659865/1e9092be-a061-4855-84ca-7ab6329042fb)